### PR TITLE
Solucionado el error que mostraba las notificaciones al autor de ella…

### DIFF
--- a/app/Models/Comentario.php
+++ b/app/Models/Comentario.php
@@ -35,4 +35,9 @@ class Comentario extends Model
     {
         return $this->hasMany(Notification::class);
     }
+
+    public function commentable()
+    {
+        return $this->morphTo();
+    }
 }

--- a/app/Models/Like.php
+++ b/app/Models/Like.php
@@ -22,5 +22,10 @@ class Like extends Model
         return $this->hasOne(Notification::class);
     }
 
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
 
 }

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -50,4 +50,25 @@ class Notification extends Model
         return $this->comentarios->belongsTo(User::class, 'autor');
     }
 
+    public function author()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function type()
+    {
+        return $this->morphTo('notifiable');
+    }
+
+    public function scopeForUser($query, $userId)
+    {
+        return $query->whereHasMorph('notifiable', [Post::class, Comentario::class], function ($query, $type) use ($userId) {
+            $query->whereHas('user', function ($query) use ($userId) {
+                $query->where('id', $userId);
+            });
+        });
+    }
+
+
+
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -90,7 +90,7 @@
 
                         @auth
                             @php($user = \App\Models\User::find(auth()->id()))
-                            @php($notifications = $user->allNotifications()->get())
+                            @php($notifications = \App\Models\Notification::forUser($user->id)->latest()->get())
 
 
                             <li class="nav-item dropdown mt-1" id="notificaciones">
@@ -107,7 +107,7 @@
                                 <ul class="dropdown-menu dropdown-menu-dark" style="width: 22rem;">
 
                             @forelse($notifications as $notification)
-                                @php( $user = \App\Models\User::find($notification->user_id))
+                                @php( $authorNotification = \App\Models\User::find($notification->user_id))
                                 @if( $notification->notifiable_type == 'c')
                                     @php( $comment = \App\Models\Comentario::find($notification->notifiable_id))
                                 @endif
@@ -122,7 +122,7 @@
                                             @php( $postN = \App\Models\Post::find($notification->notifiable_id ))
                                     @php( $element = "<a href='".route('posts.show', $postN)."' class='text-reset' style='text-decoration: none'>publicación </a>")
                                 @elseif( $notification->notifiable_type == 'c')
-                                    @php( $postN = \App\Models\Post::find(\App\Models\Comentario::find($notification->notifiable_id)->id))
+                                    @php( $postN = \App\Models\Post::find(\App\Models\Comentario::find($notification->notifiable_id)->post_id))
                                     @if(!is_null($comment->respuestaA))
                                         @php( $autor = \App\Models\User::find(\App\Models\Comentario::find($notification->notifiable_id)->autor ))
                                         @php( $element = "respuesta al comentario de <a href='".route('users.show', $autor)."' class='text-reset' style='text-decoration: none'>".$autor->name."</a> en la <a href='".route('posts.show', $postN)."' class='text-reset' style='text-decoration: none'>publicación </a> de <a href='".route('users.show', $comment->post->user)."' class='text-reset' style='text-decoration: none'>".$comment->post->user->name."</a>")
@@ -135,9 +135,9 @@
                                                     <div class="card-body p-1">
                                                         <a href="#">
                                                             <div class="row" onclick="window.location.href = '{{ route('notifications.show', ['notification' => $notification->id, 'postId' => $postN->id]) }}';" style="cursor: pointer;">
-                                                            <div class="col-3 pe-0"><a href="{{ route('users.show', $user) }}"><img class="w-100 rounded-circle" src="{{ $user->profile_photo_url }}"></a></div>
+                                                            <div class="col-3 pe-0"><a href="{{ route('users.show', $authorNotification) }}"><img class="w-100 rounded-circle" src="{{ $authorNotification->profile_photo_url }}"></a></div>
                                                                 <div class="col text-reset ps-2">
-                                                                    <strong><a href="{{ route('users.show', $user) }}" class="text-reset" style="text-decoration: none">{{ $user->name }} </a></strong><br>
+                                                                    <strong><a href="{{ route('users.show', $authorNotification) }}" class="text-reset" style="text-decoration: none">{{ $authorNotification->name }} </a></strong><br>
                                                                     {!! $action !!} {!! $element !!}
                                                                 </div>
                                                             </div>

--- a/resources/views/livewire/post-comments.blade.php
+++ b/resources/views/livewire/post-comments.blade.php
@@ -15,7 +15,7 @@
         @if($post->user)
             <div class="col-md-2 justify-content-center"
                  onclick="window.location.href='{{route('users.show', $post->user)}}'" style="cursor: pointer">
-                <img src="{{ $post->user->profile_photo_path }}" width="60" height="60" class="rounded-circle"><br>
+                <img src="{{ $post->user->profile_photo_url }}" width="60" height="60" class="rounded-circle"><br>
                 {{ $post->user->name }}
             </div>
         @else
@@ -44,8 +44,8 @@
                                     @forelse($this->comments->get() as $comentario)
                                         @php($fechaComentario = \Carbon\Carbon::parse($comentario->created_at))
                                         @if(is_null($comentario->respuestaA))
-                                            @if($comentario->user->profile_photo_path)
-                                                @php($profile_photo_url = $comentario->user->profile_photo_path)
+                                            @if($comentario->user->profile_photo_url)
+                                                @php($profile_photo_url = $comentario->user->profile_photo_url)
                                             @else
                                                 @php($profile_photo_url = '/images/pp.webp')
                                             @endif
@@ -102,7 +102,7 @@
                                                                     <div class="d-flex flex-start w-100 mt-3">
                                                                         <img
                                                                             class="rounded-circle shadow-1-strong me-3 profile_pct"
-                                                                            src="@if(is_null(auth()->user()->profile_photo_path)) /images/pp.webp @else(auth()->user()->profile_photo_path) @endif"
+                                                                            src="{{ auth()->user()->profile_photo_url }}"
                                                                             alt="{{auth()->user()->name}}"
                                                                             width="35"
                                                                             height="35"/>
@@ -136,11 +136,6 @@
                                                     @foreach($comentario->respuesta as $respuesta)
                                                         @php($fechaRespuesta = \Carbon\Carbon::parse($respuesta->created_at))
                                                         @if($comentario->id == $respuesta->respuestaA)
-                                                            @if(($respuesta->user->profile_photo_path))
-                                                                @php($profile_photo_url = $respuesta->user->profile_photo_path)
-                                                            @else
-                                                                @php($profile_photo_url = '/images/pp.webp')
-                                                            @endif
                                                             @if($respuesta->user)
                                                                 @php($author_name = $respuesta->user->name)
                                                             @else
@@ -153,14 +148,14 @@
                                                                        href="{{ route('users.show', $respuesta->user) }}">
                                                                         <img
                                                                             class="rounded-circle shadow-1-strong profile_pct"
-                                                                            src="{{ $profile_photo_url }}"
+                                                                            src="{{ $respuesta->user->profile_photo_url }}"
                                                                             alt="{{ $author_name }}"
                                                                             width="65" height="65"/>
                                                                     </a>
                                                                 @else
                                                                     <img
                                                                         class="rounded-circle shadow-1-strong profile_pct"
-                                                                        src="{{ $profile_photo_url }}"
+                                                                        src="/images/pp.jpg"
                                                                         alt="{{ $author_name }}"
                                                                         width="65" height="65"/>
                                                                 @endif
@@ -222,7 +217,7 @@
                         <div class="card-body p-4">
                             <div class="d-flex flex-start w-100">
                                 <img class="rounded-circle shadow-1-strong me-3 profile_pct"
-                                     src="@if(is_null(auth()->user()->profile_photo_path)) /images/pp.webp @else(auth()->user()->profile_photo_path) @endif"
+                                     src="{{auth()->user()->profile_photo_url}}"
                                      alt="{{auth()->user()->name}}"
                                      width="65"
                                      height="65"/>


### PR DESCRIPTION
…s y no al autor de los posts o comentarios que se les dio like.

Solucionado el error en el que cuando el like era de un comentario, no redirigía al post correspondiente. Cuando el usuario no tiene foto de perfil, se muestran sus iniciales en su post y/o comentarios.